### PR TITLE
Issue 56

### DIFF
--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -14,6 +14,13 @@ export const enum SessionSorting {
   EndedAt = 'endedAt'
 }
 
+export const enum SessionDataType {
+  MSeries = 'mSeries',
+  Strength = 'strength',
+  HeartRate = 'heartRate',
+  Session = 'session'
+}
+
 export interface SessionData {
   id: number
   echipId: string | null
@@ -22,6 +29,9 @@ export interface SessionData {
   endedAt: string | null
   user?: UserData
   facility?: FacilityData
+  hasMSeriesDataSets: boolean
+  hasStrengthMachineDataSets: boolean
+  hasHeartRateDataSets: boolean
 
   /**
    * @todo Add Session Plan Sequence Instance model
@@ -94,6 +104,18 @@ export class StaticSession {
 
   get facility () {
     return this._sessionData.facility
+  }
+
+  get hasMSeriesDataSets () {
+    return this._sessionData.hasMSeriesDataSets
+  }
+
+  get hasStrengthMachineDataSets () {
+    return this._sessionData.hasStrengthMachineDataSets
+  }
+
+  get hasHeartRateDataSets () {
+    return this._sessionData.hasHeartRateDataSets
   }
 
   get heartRateDataSets () {
@@ -172,6 +194,18 @@ export class Session extends Model {
 
   get endedAt () {
     return this._sessionData.endedAt !== null ? new Date(this._sessionData.endedAt) : null
+  }
+
+  get hasMSeriesDataSets () {
+    return this._sessionData.hasMSeriesDataSets
+  }
+
+  get hasStrengthMachineDataSets () {
+    return this._sessionData.hasStrengthMachineDataSets
+  }
+
+  get hasHeartRateDataSets () {
+    return this._sessionData.hasHeartRateDataSets
   }
 
   /**

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -14,7 +14,7 @@ export const enum SessionSorting {
   EndedAt = 'endedAt'
 }
 
-export const enum SessionDataType {
+export const enum SessionRequireExtendedDataType {
   MSeries = 'mSeries',
   Strength = 'strength',
   HeartRate = 'heartRate',

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,7 +14,7 @@ import { MSeriesFtpMeasurement, MSeriesFtpMeasurementListResponse, MSeriesFtpMea
 import { OAuthProviders, OAuthService, OAuthServiceData, OAuthServiceListResponse, OAuthServiceResponse, OAuthServices } from './oauthService'
 import { PrimaryEmailAddress, PrimaryEmailAddressData, PrimaryEmailAddressResponse } from './primaryEmailAddress'
 import { Profile, ProfileData } from './profile'
-import { FacilitySession, FacilitySessions, Session, SessionDataType, SessionListResponse, SessionResponse, Sessions, SessionSorting } from './session'
+import { FacilitySession, FacilitySessions, Session, SessionListResponse, SessionRequireExtendedDataType, SessionResponse, Sessions, SessionSorting } from './session'
 import { ForceUnit, ResistancePrecision, StrengthMachineDataSet, StrengthMachineDataSetListResponse, StrengthMachineDataSetResponse, StrengthMachineDataSets, StrengthMachineDataSetSorting } from './strengthMachineDataSet'
 import { UserInBodyIntegration, UserInBodyIntegrationResponse } from './userInBodyIntegration'
 import { WeightMeasurement, WeightMeasurementData, WeightMeasurementListResponse, WeightMeasurementResponse, WeightMeasurements, WeightMeasurementSorting } from './weightMeasurement'
@@ -279,7 +279,7 @@ export class User extends Model {
     return new Session(session, this.sessionHandler)
   }
 
-  async getSessions (options: { open?: boolean, dataType?: SessionDataType, from?: Date, to?: Date, sort?: SessionSorting, ascending?: boolean, limit?: number, offset?: number } = { }) {
+  async getSessions (options: { open?: boolean, requireExtendedDataType?: SessionRequireExtendedDataType, from?: Date, to?: Date, sort?: SessionSorting, ascending?: boolean, limit?: number, offset?: number } = { }) {
     const { sessions, sessionsMeta } = await this.action('session:list', { ...options, userId: this.id }) as SessionListResponse
     return new Sessions(sessions, sessionsMeta, this.sessionHandler)
   }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,7 +14,7 @@ import { MSeriesFtpMeasurement, MSeriesFtpMeasurementListResponse, MSeriesFtpMea
 import { OAuthProviders, OAuthService, OAuthServiceData, OAuthServiceListResponse, OAuthServiceResponse, OAuthServices } from './oauthService'
 import { PrimaryEmailAddress, PrimaryEmailAddressData, PrimaryEmailAddressResponse } from './primaryEmailAddress'
 import { Profile, ProfileData } from './profile'
-import { FacilitySession, FacilitySessions, Session, SessionListResponse, SessionResponse, Sessions, SessionSorting } from './session'
+import { FacilitySession, FacilitySessions, Session, SessionDataType, SessionListResponse, SessionResponse, Sessions, SessionSorting } from './session'
 import { ForceUnit, ResistancePrecision, StrengthMachineDataSet, StrengthMachineDataSetListResponse, StrengthMachineDataSetResponse, StrengthMachineDataSets, StrengthMachineDataSetSorting } from './strengthMachineDataSet'
 import { UserInBodyIntegration, UserInBodyIntegrationResponse } from './userInBodyIntegration'
 import { WeightMeasurement, WeightMeasurementData, WeightMeasurementListResponse, WeightMeasurementResponse, WeightMeasurements, WeightMeasurementSorting } from './weightMeasurement'
@@ -209,7 +209,7 @@ export class User extends Model {
     return typeof this._userData.heightMeasurements !== 'undefined' ? this._userData.heightMeasurements.map(heightMeasurement => new HeightMeasurement(heightMeasurement, this.sessionHandler)) : undefined
   }
 
-  async createHeightMeasurement (params: { source: string, takenAt: Date, bodyFatPercentage?: number }  & XOR<{ metricHeight: number }, { imperialHeight: number }>) {
+  async createHeightMeasurement (params: { source: string, takenAt: Date, bodyFatPercentage?: number } & XOR<{ metricHeight: number }, { imperialHeight: number }>) {
     const { heightMeasurement } = await this.action('heightMeasurement:create', { ...params, userId: this.id }) as HeightMeasurementResponse
     return new HeightMeasurement(heightMeasurement, this.sessionHandler)
   }
@@ -279,7 +279,7 @@ export class User extends Model {
     return new Session(session, this.sessionHandler)
   }
 
-  async getSessions (options: { open?: boolean, from?: Date, to?: Date, sort?: SessionSorting, ascending?: boolean, limit?: number, offset?: number } = { }) {
+  async getSessions (options: { open?: boolean, dataType?: SessionDataType, from?: Date, to?: Date, sort?: SessionSorting, ascending?: boolean, limit?: number, offset?: number } = { }) {
     const { sessions, sessionsMeta } = await this.action('session:list', { ...options, userId: this.id }) as SessionListResponse
     return new Sessions(sessions, sessionsMeta, this.sessionHandler)
   }
@@ -373,7 +373,7 @@ export class FacilityMemberUser extends FacilityUser {
   }
 
   async getSession (params: { id: number }) {
-    const { session } = await this.action('facilitySession:show', { ...params, userId: this.id }) as SessionResponse
+    const { session } = await this.action('facilitySession:show', params) as SessionResponse
     return new FacilitySession(session, this.sessionHandler)
   }
 


### PR DESCRIPTION
Updates session model to include the newest properties.  Reference #56 for those changes.

Fixes `FacilitySession.getSession` request because that end point only allows `userId` or `id` parameter to be passed in.  It was passing in both.