### PR TITLE
issue 203

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -167,7 +167,7 @@ export class AdminSession extends UserSession {
     return new PrivilegedStrengthExercises(strengthExercises, strengthExercisesMeta, this.sessionHandler)
   }
 
-  async createStrengthExercise (params: { defaultExerciseAlias: string, category: StrengthExerciseCategory, movement: StrengthExerciseMovementDEP, plane: StrengthExercisePlane, humanMovement: StrengthExerciseMovement }) {
+  async createStrengthExercise (params: { defaultExerciseAlias: string, category: StrengthExerciseCategory, movement?: StrengthExerciseMovementDEP, plane: StrengthExercisePlane, humanMovement: StrengthExerciseMovement }) {
     const { strengthExercise } = await this.action('strengthExercise:create', params) as StrengthExerciseResponse
     return new PrivilegedStrengthExercise(strengthExercise, this.sessionHandler)
   }

--- a/src/models/strengthExercise.ts
+++ b/src/models/strengthExercise.ts
@@ -152,7 +152,7 @@ export class PrivilegedStrengthExercises extends ModelList<PrivilegedStrengthExe
 
 /** @hidden */
 export class PrivilegedStrengthExercise extends StrengthExercise {
-  async update (params: { category: StrengthExerciseCategory, movement: StrengthExerciseMovementDEP, plane: StrengthExercisePlane, humanMovement: StrengthExerciseMovement }) {
+  async update (params: { category: StrengthExerciseCategory, movement?: StrengthExerciseMovementDEP, plane: StrengthExercisePlane, humanMovement: StrengthExerciseMovement }) {
     const { strengthExercise } = await this.action('strengthExercise:update', { ...params, id: this.id }) as StrengthExerciseResponse
     this.setStrengthExerciseData(strengthExercise)
     return this


### PR DESCRIPTION
Make Deprecated movement field optional
Johnathan pointed out this was missing in the recent SDK update since the API action doesn't require the field. 