### PR TITLE
Issue 209

### DIFF
--- a/src/models/strengthMachineDataSet.ts
+++ b/src/models/strengthMachineDataSet.ts
@@ -266,7 +266,7 @@ export class StrengthMachineDataSet extends SubscribableModel {
   }
 
   getFlatExportUrl (params: { format: StrengthMachineDataSetExportFormat }) {
-    const url = new URL(this.sessionHandler.connection.baseUrl.toString() + `/user/${this._strengthMachineDataSetData.userId.toString()}/strength-machine-data-set/${this.id}.${params.format}`)
+    const url = new URL(this.sessionHandler.connection.baseUrl.toString() + `/user/${this._strengthMachineDataSetData.userId.toString()}/strength-machine-data-set/export/${this.id}.${params.format}`)
     url.searchParams.append('authorization', this.sessionHandler.accessToken)
     return url.toString()
   }


### PR DESCRIPTION
Changed the export URL to include `/export/` in the path for flat data exports. This aligns with the updated API endpoint structure.

Closes #209 

Addresses and Fixes Facilities Issue:
https://github.com/KeiserCorp/Keiser.Metrics.Facility/issues/241 