### PR TITLE
Update endpoints and pin auth apiVersion

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
-export const DEFAULT_REST_ENDPOINT =
-  'https://metrics-api-v3.keiser.com/api'
-export const DEFAULT_SOCKET_ENDPOINT =
-  'wss://metrics-api-v3.keiser.com/ws'
+export const DEFAULT_REST_ENDPOINT = 'https://metrics-api.keiser.com/api'
+export const DEFAULT_SOCKET_ENDPOINT = 'wss://metrics-api.keiser.com/ws'
 export const DEFAULT_REQUEST_TIMEOUT = 5000
 export const JWT_TTL_LIMIT = 5000
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,12 @@ import { Core } from './models/core'
 import { Gender } from './models/profile'
 import { StrengthMachineIdentifier } from './models/strengthMachine'
 import { UserResponse } from './models/user'
-import { KioskSession, StrengthMachineInitializeResponse, StrengthMachineSession, UserSession } from './session'
+import {
+  KioskSession,
+  StrengthMachineInitializeResponse,
+  StrengthMachineSession,
+  UserSession
+} from './session'
 
 interface SSORequestParameters {
   returnUrl: string
@@ -36,7 +41,7 @@ export default class Metrics {
   protected readonly _connection: MetricsConnection
   protected readonly _core: Core
 
-  constructor (options: ConnectionOptions = { }) {
+  constructor (options: ConnectionOptions = {}) {
     this._connection = new MetricsConnection(options)
     this._core = new Core(this._connection)
   }
@@ -61,7 +66,7 @@ export default class Metrics {
     this._connection.dispose()
   }
 
-  async action (action: ActionName, params: Object = { }) {
+  async action (action: ActionName, params: Object = {}) {
     return await this._connection.action(action, params)
   }
 
@@ -69,57 +74,102 @@ export default class Metrics {
     return this._connection.onConnectionChangeEvent
   }
 
-  async generateSSORequestUrl (requestParameters: SSORequestParameters, userParameters?: UserSSOParameters) {
-    const response = await this._connection.action('core:endpoints') as CoreEndpointResponse
+  async generateSSORequestUrl (
+    requestParameters: SSORequestParameters,
+    userParameters?: UserSSOParameters
+  ) {
+    const response = (await this._connection.action(
+      'core:endpoints'
+    )) as CoreEndpointResponse
     const ssoUrl = new URL(response.endpoints.sso)
-    for (const [name, value] of [...Object.entries(requestParameters), ...Object.entries(userParameters ?? {})]) {
+    for (const [name, value] of [
+      ...Object.entries(requestParameters),
+      ...Object.entries(userParameters ?? {})
+    ]) {
       ssoUrl.searchParams.append(name, value)
     }
     return ssoUrl
   }
 
-  async authenticateWithExchangeToken (params: { exchangeToken: string}) {
-    const response = await this._connection.action('auth:exchangeFulfillment', params) as UserResponse
+  async authenticateWithExchangeToken (params: { exchangeToken: string }) {
+    const response = (await this._connection.action(
+      'auth:exchangeFulfillment',
+      params
+    )) as UserResponse
     return new UserSession(response, this._connection)
   }
 
   /** @deprecated */
-  async authenticateWithCredentials (params: { email: string, password: string, refreshable?: boolean }) {
-    const response = await this._connection.action('auth:login', { refreshable: true, ...params }) as UserResponse
+  async authenticateWithCredentials (params: {
+    email: string
+    password: string
+    refreshable?: boolean
+  }) {
+    const response = (await this._connection.action('auth:login', {
+      refreshable: true,
+      apiVersion: 1,
+      ...params
+    })) as UserResponse
     return new UserSession(response, this._connection)
   }
 
   /** @deprecated */
-  async authenticateWithWelcomeToken (params: { welcomeToken: string, password: string, refreshable?: boolean }) {
-    const response = await this._connection.action('auth:facilityWelcomeFulfillment', { refreshable: true, ...params }) as UserResponse
+  async authenticateWithWelcomeToken (params: {
+    welcomeToken: string
+    password: string
+    refreshable?: boolean
+  }) {
+    const response = (await this._connection.action(
+      'auth:facilityWelcomeFulfillment',
+      { refreshable: true, ...params }
+    )) as UserResponse
     return new UserSession(response, this._connection)
   }
 
   async authenticateWithToken (params: { token: string }) {
-    const response = await this._connection.action('user:show', { authorization: params.token }) as UserResponse
+    const response = (await this._connection.action('user:show', {
+      authorization: params.token
+    })) as UserResponse
     return new UserSession(response, this._connection)
   }
 
   async authenticateWithKioskToken (params: { kioskToken: string }) {
-    await this._connection.action('facilityKioskToken:check', { authorization: params.kioskToken })
-    return new KioskSession({ accessToken: params.kioskToken }, this._connection)
+    await this._connection.action('facilityKioskToken:check', {
+      authorization: params.kioskToken
+    })
+    return new KioskSession(
+      { accessToken: params.kioskToken },
+      this._connection
+    )
   }
 
-  async authenticateWithMachineToken (params: { machineToken: string, strengthMachineIdentifier: StrengthMachineIdentifier }) {
+  async authenticateWithMachineToken (params: {
+    machineToken: string
+    strengthMachineIdentifier: StrengthMachineIdentifier
+  }) {
     const initializationParams = {
       ...params.strengthMachineIdentifier,
       authorization: params.machineToken
     }
-    const response = await this._connection.action('a500:initialize', initializationParams) as StrengthMachineInitializeResponse
+    const response = (await this._connection.action(
+      'a500:initialize',
+      initializationParams
+    )) as StrengthMachineInitializeResponse
     return new StrengthMachineSession(response, this._connection)
   }
 
-  async authenticateWithMachineInitializerToken (params: { machineInitializerToken: string, strengthMachineIdentifier: StrengthMachineIdentifier }) {
+  async authenticateWithMachineInitializerToken (params: {
+    machineInitializerToken: string
+    strengthMachineIdentifier: StrengthMachineIdentifier
+  }) {
     const initializationParams = {
       ...params.strengthMachineIdentifier,
       authorization: params.machineInitializerToken
     }
-    const response = await this._connection.action('a500:initialize', initializationParams) as StrengthMachineInitializeResponse
+    const response = (await this._connection.action(
+      'a500:initialize',
+      initializationParams
+    )) as StrengthMachineInitializeResponse
     return new StrengthMachineSession(response, this._connection)
   }
 }

--- a/src/models/facilityAccessControlKiosk.ts
+++ b/src/models/facilityAccessControlKiosk.ts
@@ -5,7 +5,7 @@ export enum PrimaryIdentification {
   UUID = 'uuid',
   MemberIdentifier = 'memberIdentifier',
   EmailAddress = 'emailAddress',
-  FullName = 'fullName'
+  FullName = 'fullName',
 }
 
 export enum SecondaryIdentification {
@@ -13,7 +13,7 @@ export enum SecondaryIdentification {
   UUID = 'uuid',
   MemberIdentifier = 'memberIdentifier',
   YearOfBirth = 'yearOfBirth',
-  MemberSecret = 'memberSecret'
+  MemberSecret = 'memberSecret',
 }
 
 export interface FacilityAccessControlKioskData {
@@ -30,17 +30,24 @@ export interface FacilityAccessControlKioskResponse extends AuthenticatedRespons
 export class FacilityAccessControlKiosk extends Model {
   private _facilityAccessControlKioskData: FacilityAccessControlKioskData
 
-  constructor (facilityAccessControlKioskData: FacilityAccessControlKioskData, sessionHandler: SessionHandler) {
+  constructor (
+    facilityAccessControlKioskData: FacilityAccessControlKioskData,
+    sessionHandler: SessionHandler
+  ) {
     super(sessionHandler)
     this._facilityAccessControlKioskData = facilityAccessControlKioskData
   }
 
-  private setFacilityAccessControlKioskData (facilityAccessControlKioskData: FacilityAccessControlKioskData) {
+  private setFacilityAccessControlKioskData (
+    facilityAccessControlKioskData: FacilityAccessControlKioskData
+  ) {
     this._facilityAccessControlKioskData = facilityAccessControlKioskData
   }
 
   async reload () {
-    const { facilityAccessControlKiosk } = await this.action('facilityAccessControlKiosk:show') as FacilityAccessControlKioskResponse
+    const { facilityAccessControlKiosk } = (await this.action(
+      'facilityAccessControlKiosk:show'
+    )) as FacilityAccessControlKioskResponse
     this.setFacilityAccessControlKioskData(facilityAccessControlKiosk)
     return this
   }
@@ -51,7 +58,10 @@ export class FacilityAccessControlKiosk extends Model {
     primaryIdentification?: PrimaryIdentification
     secondaryIdentification?: SecondaryIdentification
   }) {
-    const { facilityAccessControlKiosk } = await this.action('facilityAccessControlKiosk:update', { ...params }) as FacilityAccessControlKioskResponse
+    const { facilityAccessControlKiosk } = (await this.action(
+      'facilityAccessControlKiosk:update',
+      { apiVersion: 1, ...params }
+    )) as FacilityAccessControlKioskResponse
     this.setFacilityAccessControlKioskData(facilityAccessControlKiosk)
     return this
   }
@@ -69,7 +79,8 @@ export class FacilityAccessControlKiosk extends Model {
   }
 
   get isFingerprintAuthenticationAllowed () {
-    return this._facilityAccessControlKioskData.isFingerprintAuthenticationAllowed
+    return this._facilityAccessControlKioskData
+      .isFingerprintAuthenticationAllowed
   }
 
   get primaryIdentification () {

--- a/src/sso.ts
+++ b/src/sso.ts
@@ -3,80 +3,177 @@ import { Units } from './constants'
 import Metrics from './core'
 import { ClientSideActionPrevented } from './error'
 import { DecodeJWT } from './lib/jwt'
-import { GlobalAccessControl, GlobalAccessControlData } from './models/globalAccessControl'
+import {
+  GlobalAccessControl,
+  GlobalAccessControlData
+} from './models/globalAccessControl'
 import { OAuthProviders } from './models/oauthService'
 import { Gender } from './models/profile'
 import { ExchangeableUserResponse } from './models/user'
-import { CheckReturnRouteResponse, RedirectResponse, UserSession } from './session'
+import {
+  CheckReturnRouteResponse,
+  RedirectResponse,
+  UserSession
+} from './session'
 
 export default class MetricsSSO extends Metrics {
-  async isReturnRouteValid (params: {returnUrl: string}) {
-    const response = await this._connection.action('auth:validateReturnRoute', params) as CheckReturnRouteResponse
+  async isReturnRouteValid (params: { returnUrl: string }) {
+    const response = (await this._connection.action(
+      'auth:validateReturnRoute',
+      params
+    )) as CheckReturnRouteResponse
     return response.valid
   }
 
   async authenticateWithToken (params: { token: string }) {
-    const response = await this._connection.action('auth:exchangeInit', { authorization: params.token }) as ExchangeableUserResponse
+    const response = (await this._connection.action('auth:exchangeInit', {
+      authorization: params.token
+    })) as ExchangeableUserResponse
     return new ExchangeableUserSession(response, this._connection)
   }
 
-  async authenticateWithCredentials (params: { email: string, password: string, refreshable?: boolean, requiresElevated?: boolean}) {
-    const response = await this._connection.action('auth:login', { refreshable: true, ...params }) as ExchangeableUserResponse
+  async authenticateWithCredentials (params: {
+    email: string
+    password: string
+    refreshable?: boolean
+    requiresElevated?: boolean
+  }) {
+    const response = (await this._connection.action('auth:login', {
+      refreshable: true,
+      apiVersion: 1,
+      ...params
+    })) as ExchangeableUserResponse
     return new ExchangeableUserSession(response, this._connection)
   }
 
-  async initializeUserCreation (params: { email: string, returnUrl: string, requiresElevated?: boolean, name?: string, birthday?: string, gender?: Gender, language?: string, units?: Units, metricWeight?: number, metricHeight?: number }) {
+  async initializeUserCreation (params: {
+    email: string
+    returnUrl: string
+    requiresElevated?: boolean
+    name?: string
+    birthday?: string
+    gender?: Gender
+    language?: string
+    units?: Units
+    metricWeight?: number
+    metricHeight?: number
+  }) {
     await this._connection.action('auth:userInit', params)
   }
 
-  async initiatePasswordReset (params: { email: string, returnUrl: string, requiresElevated?: boolean }) {
+  async initiatePasswordReset (params: {
+    email: string
+    returnUrl: string
+    requiresElevated?: boolean
+  }) {
     await this._connection.action('auth:resetRequest', { ...params })
   }
 
-  async fulfillUserCreation (params: { authorizationCode: string, password: string, refreshable?: boolean, requiresElevated?: boolean, acceptedTermsRevision: string, name: string, birthday: string, gender: Gender, language?: string, units: Units, metricWeight?: number, metricHeight?: number}) {
-    const response = await this._connection.action('auth:userInitFulfillment', { refreshable: true, ...params }) as ExchangeableUserResponse
+  async fulfillUserCreation (params: {
+    authorizationCode: string
+    password: string
+    refreshable?: boolean
+    requiresElevated?: boolean
+    acceptedTermsRevision: string
+    name: string
+    birthday: string
+    gender: Gender
+    language?: string
+    units: Units
+    metricWeight?: number
+    metricHeight?: number
+  }) {
+    const response = (await this._connection.action(
+      'auth:userInitFulfillment',
+      { refreshable: true, ...params }
+    )) as ExchangeableUserResponse
     return new ExchangeableUserSession(response, this._connection)
   }
 
-  async authenticateWithWelcomeToken (params: { welcomeToken: string, password: string, refreshable?: boolean }) {
-    const response = await this._connection.action('auth:facilityWelcomeFulfillment', { refreshable: true, ...params }) as ExchangeableUserResponse
+  async authenticateWithWelcomeToken (params: {
+    welcomeToken: string
+    password: string
+    refreshable?: boolean
+  }) {
+    const response = (await this._connection.action(
+      'auth:facilityWelcomeFulfillment',
+      { refreshable: true, ...params }
+    )) as ExchangeableUserResponse
     return new ExchangeableUserSession(response, this._connection)
   }
 
   async initiateOAuthWithFacebook (params: { redirect: string }) {
-    const response = await this._connection.action('oauth:initiate', { ...params, type: 'login', service: OAuthProviders.Facebook }) as RedirectResponse
+    const response = (await this._connection.action('oauth:initiate', {
+      ...params,
+      type: 'login',
+      service: OAuthProviders.Facebook
+    })) as RedirectResponse
     return { redirectUrl: response.url }
   }
 
   async initiateOAuthWithGoogle (params: { redirect: string }) {
-    const response = await this._connection.action('oauth:initiate', { ...params, type: 'login', service: OAuthProviders.Google }) as RedirectResponse
+    const response = (await this._connection.action('oauth:initiate', {
+      ...params,
+      type: 'login',
+      service: OAuthProviders.Google
+    })) as RedirectResponse
     return { redirectUrl: response.url }
   }
 
   async initiateOAuthWithApple (params: { redirect: string }) {
-    const response = await this._connection.action('oauth:initiate', { ...params, type: 'login', service: OAuthProviders.Apple }) as RedirectResponse
+    const response = (await this._connection.action('oauth:initiate', {
+      ...params,
+      type: 'login',
+      service: OAuthProviders.Apple
+    })) as RedirectResponse
     return { redirectUrl: response.url }
   }
 
-  async authenticateWithResetToken (params: { resetToken: string, password: string, refreshable?: boolean, requiresElevated?: boolean}) {
-    const response = await this._connection.action('auth:resetFulfillment', { refreshable: true, ...params }) as ExchangeableUserResponse
+  async authenticateWithResetToken (params: {
+    resetToken: string
+    password: string
+    refreshable?: boolean
+    requiresElevated?: boolean
+  }) {
+    const response = (await this._connection.action('auth:resetFulfillment', {
+      refreshable: true,
+      ...params
+    })) as ExchangeableUserResponse
     return new ExchangeableUserSession(response, this._connection)
   }
 
-  async elevateUserSession (userSession: UserSession, params: { otpToken: string, refreshable?: boolean }) {
-    const response = await userSession.sessionHandler.action('auth:elevate', { refreshable: true, ...params }) as ExchangeableUserResponse
+  async elevateUserSession (
+    userSession: UserSession,
+    params: { otpToken: string, refreshable?: boolean }
+  ) {
+    const response = (await userSession.sessionHandler.action('auth:elevate', {
+      refreshable: true,
+      ...params
+    })) as ExchangeableUserResponse
     const accessToken = DecodeJWT(response.accessToken)
-    if (typeof accessToken.globalAccessControl === 'undefined' || accessToken.globalAccessControl === null) {
-      throw new ClientSideActionPrevented({ explanation: 'Session token is not valid for admin session.' })
+    if (
+      typeof accessToken.globalAccessControl === 'undefined' ||
+      accessToken.globalAccessControl === null
+    ) {
+      throw new ClientSideActionPrevented({
+        explanation: 'Session token is not valid for admin session.'
+      })
     }
-    return new ExchangeableAdminSession(response, userSession.sessionHandler.connection, accessToken.globalAccessControl)
+    return new ExchangeableAdminSession(
+      response,
+      userSession.sessionHandler.connection,
+      accessToken.globalAccessControl
+    )
   }
 }
 
 export class ExchangeableUserSession extends UserSession {
   protected readonly _exchangeToken: string
 
-  constructor (exchangeableUserResponse: ExchangeableUserResponse, connection: MetricsConnection) {
+  constructor (
+    exchangeableUserResponse: ExchangeableUserResponse,
+    connection: MetricsConnection
+  ) {
     super(exchangeableUserResponse, connection)
     this._exchangeToken = exchangeableUserResponse.exchangeToken
   }
@@ -89,9 +186,16 @@ export class ExchangeableUserSession extends UserSession {
 export class ExchangeableAdminSession extends ExchangeableUserSession {
   private readonly _globalAccessControl: GlobalAccessControl
 
-  constructor (exchangeableUserResponse: ExchangeableUserResponse, connection: MetricsConnection, globalAccessControlData: GlobalAccessControlData) {
+  constructor (
+    exchangeableUserResponse: ExchangeableUserResponse,
+    connection: MetricsConnection,
+    globalAccessControlData: GlobalAccessControlData
+  ) {
     super(exchangeableUserResponse, connection)
-    this._globalAccessControl = new GlobalAccessControl(globalAccessControlData, this.sessionHandler)
+    this._globalAccessControl = new GlobalAccessControl(
+      globalAccessControlData,
+      this.sessionHandler
+    )
   }
 
   get globalAccessControl () {

--- a/test/mSeriesDataSet.spec.ts
+++ b/test/mSeriesDataSet.spec.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai'
 
 import Metrics from '../src/core'
 import { ActionErrorProperties, UnknownEntityError } from '../src/error'
-import { MSeriesDataSet, MSeriesDataSetSorting } from '../src/models/mSeriesDataSet'
+import {
+  MSeriesDataSet,
+  MSeriesDataSetSorting
+} from '../src/models/mSeriesDataSet'
 import { User } from '../src/models/user'
 import { ModelChangeEvent } from '../src/session'
 import { IsBrowser } from './utils/constants'
@@ -55,12 +58,16 @@ describe('M Series Data Set', function () {
   })
 
   it('can get specific M Series data set', async function () {
-    const mSeriesDataSet = await user.getMSeriesDataSet({ id: createdMSeriesDataSet.id })
+    const mSeriesDataSet = await user.getMSeriesDataSet({
+      id: createdMSeriesDataSet.id
+    })
 
     expect(typeof mSeriesDataSet).to.equal('object')
     expect(mSeriesDataSet.id).to.equal(createdMSeriesDataSet.id)
-    expect(mSeriesDataSet.buildMajor).to.equal(createdMSeriesDataSet.buildMajor)
-    expect(mSeriesDataSet.duration).to.equal(333)
+    expect(mSeriesDataSet.buildMajor).to.equal(
+      createdMSeriesDataSet.buildMajor
+    )
+    expect(mSeriesDataSet.duration).to.equal(333000)
     expect(mSeriesDataSet.initialOffset).to.equal(8)
   })
 
@@ -97,16 +104,18 @@ describe('M Series Data Set', function () {
       mSeriesDataPoints: genDataSet
     })
 
-    const modelChangeEventPromise: Promise<ModelChangeEvent> = (new Promise(resolve => {
-      const unsubscribe = mSeriesDataSet.onModelChangeEvent.subscribe(e => {
-        if (e.mutation === 'delete' && e.id === mSeriesDataSet.id) {
-          unsubscribe()
-          resolve(e)
-        }
-      })
-    }))
+    const modelChangeEventPromise: Promise<ModelChangeEvent> = new Promise(
+      (resolve) => {
+        const unsubscribe = mSeriesDataSet.onModelChangeEvent.subscribe((e) => {
+          if (e.mutation === 'delete' && e.id === mSeriesDataSet.id) {
+            unsubscribe()
+            resolve(e)
+          }
+        })
+      }
+    )
 
-    await new Promise(resolve => setTimeout(() => resolve(null), 1000))
+    await new Promise((resolve) => setTimeout(() => resolve(null), 1000))
     await mSeriesDataSet.delete()
 
     const modelChangeEvent = await modelChangeEventPromise
@@ -123,14 +132,21 @@ describe('M Series Data Set', function () {
 
     const mSeriesDataSets = await user.getMSeriesDataSets({ limit: 1 })
 
-    const modelListChangeEventPromise: Promise<ModelChangeEvent> = (new Promise(resolve => {
-      const unsubscribe = mSeriesDataSets.onModelChangeEvent.subscribe(e => {
-        if (e.mutation === 'create' && (mSeriesDataSets.length === 0 || e.id !== mSeriesDataSets[0].id)) {
-          unsubscribe()
-          resolve(e)
-        }
-      })
-    }))
+    const modelListChangeEventPromise: Promise<ModelChangeEvent> = new Promise(
+      (resolve) => {
+        const unsubscribe = mSeriesDataSets.onModelChangeEvent.subscribe(
+          (e) => {
+            if (
+              e.mutation === 'create' &&
+              (mSeriesDataSets.length === 0 || e.id !== mSeriesDataSets[0].id)
+            ) {
+              unsubscribe()
+              resolve(e)
+            }
+          }
+        )
+      }
+    )
 
     const genDataSet = generateMSeriesDataSet()
     const mSeriesDataSet = await user.createMSeriesDataSet({

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -3,7 +3,12 @@ import Metrics from '../../src/core'
 import { UserResponse } from '../../src/models/user'
 import { UserSession } from '../../src/session'
 import MetricsSSO from '../../src/sso'
-import { DemoEmail, DemoPassword, DevRestEndpoint, DevSocketEndpoint } from './constants'
+import {
+  DemoEmail,
+  DemoPassword,
+  DevRestEndpoint,
+  DevSocketEndpoint
+} from './constants'
 import { randomCharacterSequence, randomEmailAddress } from './dummy'
 
 export function getMetricsInstance () {
@@ -32,24 +37,50 @@ export function getMetricsAdminInstance () {
 
 export async function getDemoUserSession (metrics: Metrics) {
   const metricsSSO = getMetricsSSOInstance()
-  const exchangeableUserSession = await metricsSSO.authenticateWithCredentials({ email: DemoEmail, password: DemoPassword, refreshable: true })
+  const exchangeableUserSession = await metricsSSO.authenticateWithCredentials({
+    email: DemoEmail,
+    password: DemoPassword,
+    refreshable: true
+  })
   metricsSSO.dispose()
-  return await metrics.authenticateWithExchangeToken({ exchangeToken: exchangeableUserSession.exchangeToken })
+  return await metrics.authenticateWithExchangeToken({
+    exchangeToken: exchangeableUserSession.exchangeToken
+  })
 }
 
-export async function getAuthenticatedUserSession (metrics: Metrics, params: { email: string, password: string }) {
+export async function getAuthenticatedUserSession (
+  metrics: Metrics,
+  params: { email: string, password: string }
+) {
   const metricsSSO = getMetricsSSOInstance()
-  const exchangeableUserSession = await metricsSSO.authenticateWithCredentials({ ...params, refreshable: true, requiresElevated: false })
+  const exchangeableUserSession = await metricsSSO.authenticateWithCredentials({
+    ...params,
+    refreshable: true,
+    requiresElevated: false
+  })
   metricsSSO.dispose()
-  return await metrics.authenticateWithExchangeToken({ exchangeToken: exchangeableUserSession.exchangeToken })
+  return await metrics.authenticateWithExchangeToken({
+    exchangeToken: exchangeableUserSession.exchangeToken
+  })
 }
 
-export async function createUserSession (metrics: Metrics, params: { email: string }) {
-  const userResponse = await metrics.action('dev:login', params) as UserResponse
-  return await metrics.authenticateWithToken({ token: userResponse.refreshToken ?? '' })
+export async function createUserSession (
+  metrics: Metrics,
+  params: { email: string }
+) {
+  const userResponse = (await metrics.action(
+    'dev:login',
+    params
+  )) as UserResponse
+  return await metrics.authenticateWithToken({
+    token: userResponse.refreshToken ?? ''
+  })
 }
 
-export async function createNewUserSession (metrics: Metrics, params?: { email: string, password: string }) {
+export async function createNewUserSession (
+  metrics: Metrics,
+  params?: { email: string, password: string }
+) {
   if (typeof params === 'undefined') {
     params = {
       email: randomEmailAddress(),
@@ -57,20 +88,35 @@ export async function createNewUserSession (metrics: Metrics, params?: { email: 
     }
   }
   const metricsSSO = getMetricsSSOInstance()
-  const userResponse = await metricsSSO.action('dev:userCreate', params) as UserResponse
+  const userResponse = (await metricsSSO.action(
+    'dev:userCreate',
+    params
+  )) as UserResponse
   metricsSSO.dispose()
-  return await metrics.authenticateWithToken({ token: userResponse.refreshToken ?? '' })
+  return await metrics.authenticateWithToken({
+    token: userResponse.refreshToken ?? ''
+  })
 }
 
-export async function elevateUserSession (metricsAdmin: MetricsAdmin, userSession: UserSession) {
+export async function elevateUserSession (
+  metricsAdmin: MetricsAdmin,
+  userSession: UserSession
+) {
   const metricsSSO = getMetricsSSOInstance()
-  const exchangeableUserSession = await metricsSSO.elevateUserSession(userSession, { otpToken: '000000', refreshable: true })
+  const exchangeableUserSession = await metricsSSO.elevateUserSession(
+    userSession,
+    { otpToken: '000000', refreshable: true }
+  )
   metricsSSO.dispose()
-  return await metricsAdmin.authenticateAdminWithExchangeToken({ exchangeToken: exchangeableUserSession.exchangeToken })
+  return await metricsAdmin.authenticateAdminWithExchangeToken({
+    exchangeToken: exchangeableUserSession.exchangeToken
+  })
 }
 
 export async function setActiveEmployeeFacility (userSession: UserSession) {
-  const facilities = await userSession.user.getFacilityEmploymentRelationships({ limit: 1 })
+  const facilities = await userSession.user.getFacilityEmploymentRelationships({
+    limit: 1
+  })
   const facility = facilities[0]?.eagerFacility()
   if (typeof facility === 'undefined') {
     throw new Error('No Employee Facility Available')


### PR DESCRIPTION
Bug Fixes:
Point default REST and socket endpoints at metrics-api.keiser.com instead of the v3 host so the SDK talks to the current production environment out of the box.

Minor changes:
- Pin apiVersion: 1 on auth:login and facilityAccessControlKiosk:update calls
- Expect duration in milliseconds (333000) in mSeriesDataSet test
- Reformat core, sso, facilityAccessControlKiosk, and test fixtures for readability (no behavior change)